### PR TITLE
Added Libreoffice soffice.vim and Seahourse (gnome-keyring gui)

### DIFF
--- a/gnome.conf
+++ b/gnome.conf
@@ -1,4 +1,0 @@
-# MPROTECT off
-PSmXER:
-	- /usr/bin/seahorse
-

--- a/gnome.conf
+++ b/gnome.conf
@@ -1,0 +1,4 @@
+# MPROTECT off
+PSmXER:
+	- /usr/bin/seahorse
+

--- a/libreoffice.conf
+++ b/libreoffice.conf
@@ -1,4 +1,0 @@
-# MPROTECT off
-PSmXER:
-	- /usr/lib/libreoffice/program/soffice.bin
-

--- a/libreoffice.conf
+++ b/libreoffice.conf
@@ -1,0 +1,4 @@
+# MPROTECT off
+PSmXER:
+	- /usr/lib/libreoffice/program/soffice.bin
+


### PR DESCRIPTION
I got sick of all the problems with KDE on hardened Linux. I've reinstalled Arch (to keep clean) and moved to xfce4. So, I've discovered a couple new programs that need flags.

Seahhorse gives the RWX errors but dose not crash I do think it was preventing it from opening some keyring folders.

Libreoffice /soffice.bin needs MPROTECT off on my new install. I think it is really caused by a plugin I installed. I never had a problem before.
